### PR TITLE
Changed scoring from 3 per win to N+1

### DIFF
--- a/Tournament/player.py
+++ b/Tournament/player.py
@@ -100,9 +100,9 @@ class player:
             isSideboard = "SB:" in card_
             if isSideboard:
                 card_ = card_.partition( "SB:" )[-1].strip()
-            
+
             cardName = card_.partition( " " )[-1].strip()
-                
+
             try:
                 tmpCard = cardsDB.getCard( cardName )
             except CardNotFoundError as ex:
@@ -278,18 +278,18 @@ class player:
         return digest
 
     # Tallies the number of matches that the player is in, has won, and have been certified.
-    def getMatchPoints( self, withBye: bool=True ) -> float:
+    def getMatchPoints( self, withBye: bool=True, playersPerMatch:  int=2 ) -> float:
         digest = 0
         certMatches = self.getCertMatches( withBye )
         for mtch in certMatches:
             if mtch.winner == self.discordID:
-                digest += 3 #4
+                digest += playersPerMatch + 1
             elif withBye and mtch.isBye():
-                digest += 3
+                digest += playersPerMatch + 1
             elif mtch.isDraw():
-                digest += 1 #0.5
+                digest += 1
             else: # Lose gets no points
-                digest += 0 #-2.25
+                digest += 0
         return digest
 
     # Calculates the percentage of game the player has won
@@ -337,5 +337,3 @@ class player:
         for deckTag in xmlTree.getroot().findall('deck'):
             self.decks[deckTag.attrib['ident']] = deck()
             self.decks[deckTag.attrib['ident']].importFromETree( deckTag )
-
-

--- a/Tournament/tournament.py
+++ b/Tournament/tournament.py
@@ -344,7 +344,7 @@ class tournament:
             if len(plyr.matches) == 0:
                 continue
             # Match Points
-            points = plyr.getMatchPoints()
+            points = plyr.getMatchPoints( playersPerMatch=self.playersPerMatch )
             # Match Win Percentage
             MWP = plyr.getMatchWinPercentage( withBye=False )
             # Opponent Match Win Percentage
@@ -407,7 +407,7 @@ class tournament:
         if len(Match.droppedPlayers) != 0:
             digest.add_field( name="Dropped Players", value=", ".join( [ self.players[plyr].getMention() for plyr in Match.droppedPlayers ] ) )
         if not ( Match.isCertified() or Match.stopTimer ):
-            t = round(Match.getTimeLeft( ) / 60) 
+            t = round(Match.getTimeLeft( ) / 60)
             digest.add_field( name="Time Remaining", value=f'{t if t > 0 else 0} minutes' )
         if Match.winner != "":
             if Match.winner in self.players:
@@ -567,7 +567,7 @@ class tournament:
         await self.players[plyr].drop( )
         self.players[plyr].saveXML()
         message = await self.removePlayerFromQueue( plyr )
-        
+
         # The player was dropped by an admin, so two messages need to be sent
         # TODO: The admin half of this command needs to be its own method
         if author != "":
@@ -695,7 +695,7 @@ class tournament:
                         deckHashes.append( [dck.deckHash for dck in self.players[plyr].decks.values()] )
 
                 #Try up to three times
-                while not creation_success and tries < max_tries:                    
+                while not creation_success and tries < max_tries:
                     game_made = trice_bot.createGame(game_name, game_password, len(plyrs), self.spectators_allowed, self.spectators_need_password, self.spectators_can_chat, self.spectators_can_see_hands, self.only_registered, self.player_deck_verification, playerNames, deckHashes)
 
                     creation_success = game_made.success
@@ -867,5 +867,3 @@ class tournament:
         self.matches.sort( key= lambda x: x.matchNumber )
         for plyr in self.players.values():
             plyr.matches.sort( key= lambda x: x.matchNumber )
-
-


### PR DESCRIPTION
According to the specs on the MSTR

Added a parameter to the player#getMatchPoints so that the tournament object can pass the number of players per pod to it. This way it still works for 1v1 events.

Ignore the whitespace changes, my editor automatically removes those on save (which is a good thing actually)